### PR TITLE
Fix autolink limits and add duplicate URL prevention

### DIFF
--- a/src/Models/Autolink.php
+++ b/src/Models/Autolink.php
@@ -17,16 +17,20 @@ class Autolink extends Model
 
     public static function replace(string $text): string
     {
-        $limit = Rapidez::config('seoautolink/autolink/links_limit_per_page', false);
+        $limit = (int) Rapidez::config('seoautolink/autolink/links_limit_per_page', -1);
         $counter = 0;
+
         self::all()->each(function ($autolink) use (&$text, &$counter, $limit) {
             $url = url($autolink->url);
             $link = " <a href=\"$url\" target=\"$autolink->url_target\" title=\"$autolink->url_title\">$autolink->keyword</a> ";
-            $text = preg_replace('/ '.$autolink->keyword.' (?!([^<]+)?>)/i', $link, $text, -1, $count);
-            $counter += $count;
-            if ($limit && $counter > $limit) {
+
+            if ($limit > -1 && $counter >= $limit) {
                 return false;
             }
+
+            $remaining = $limit > -1 ? max($limit - $counter, 0) : -1;
+            $text = preg_replace('/ '.$autolink->keyword.' (?!([^<]+)?>)/i', $link, $text, $remaining, $count);
+            $counter += $count;
         });
 
         return $text;

--- a/src/Models/Autolink.php
+++ b/src/Models/Autolink.php
@@ -10,6 +10,10 @@ class Autolink extends Model
 {
     protected $table = 'mst_seoautolink_link';
 
+    protected const CONFIG_LINKS_LIMIT = 'seoautolink/autolink/links_limit_per_page';
+
+    protected const CONFIG_STOP_KEYWORD_PROCESSING = 'seoautolink/autolink/stop_keyword_processing';
+
     protected static function booted()
     {
         static::addGlobalScope(new IsActiveScope());
@@ -17,20 +21,32 @@ class Autolink extends Model
 
     public static function replace(string $text): string
     {
-        $limit = (int) Rapidez::config('seoautolink/autolink/links_limit_per_page', -1);
+        $limit = (int) Rapidez::config(self::CONFIG_LINKS_LIMIT, -1);
+        $avoidDuplicateUrls = (bool) Rapidez::config(self::CONFIG_STOP_KEYWORD_PROCESSING, 0);
         $counter = 0;
+        $usedUrls = [];
 
-        self::all()->each(function ($autolink) use (&$text, &$counter, $limit) {
-            $url = url($autolink->url);
-            $link = " <a href=\"$url\" target=\"$autolink->url_target\" title=\"$autolink->url_title\">$autolink->keyword</a> ";
-
+        self::all()->each(function ($autolink) use (&$text, &$counter, &$usedUrls, $limit, $avoidDuplicateUrls) {
             if ($limit > -1 && $counter >= $limit) {
                 return false;
             }
 
+            $url = url($autolink->url);
+
+            if ($avoidDuplicateUrls && in_array($url, $usedUrls)) {
+                return;
+            }
+
             $remaining = $limit > -1 ? max($limit - $counter, 0) : -1;
+            $link = " <a href=\"$url\" target=\"$autolink->url_target\" title=\"$autolink->url_title\">$autolink->keyword</a> ";
+
             $text = preg_replace('/ '.$autolink->keyword.' (?!([^<]+)?>)/i', $link, $text, $remaining, $count);
+
             $counter += $count;
+
+            if ($count > 0) {
+                $usedUrls[] = $url;
+            }
         });
 
         return $text;

--- a/src/Models/Autolink.php
+++ b/src/Models/Autolink.php
@@ -22,22 +22,21 @@ class Autolink extends Model
     public static function replace(string $text): string
     {
         $limit = (int) Rapidez::config(self::CONFIG_LINKS_LIMIT, -1);
-        $avoidDuplicateUrls = (bool) Rapidez::config(self::CONFIG_STOP_KEYWORD_PROCESSING, 0);
         $counter = 0;
         $usedUrls = [];
 
-        self::all()->each(function ($autolink) use (&$text, &$counter, &$usedUrls, $limit, $avoidDuplicateUrls) {
-            if ($limit > -1 && $counter >= $limit) {
+        self::all()->each(function ($autolink) use (&$text, &$counter, &$usedUrls, $limit) {
+            if (self::shouldStopProcessing($counter, $limit)) {
                 return false;
             }
 
             $url = url($autolink->url);
 
-            if ($avoidDuplicateUrls && in_array($url, $usedUrls)) {
+            if (self::shouldSkipDuplicateUrl($url, $usedUrls)) {
                 return;
             }
 
-            $remaining = $limit > -1 ? max($limit - $counter, 0) : -1;
+            $remaining = self::getRemainingReplacements($autolink, $limit, $counter);
             $link = " <a href=\"$url\" target=\"$autolink->url_target\" title=\"$autolink->url_title\">$autolink->keyword</a> ";
 
             $text = preg_replace('/ '.$autolink->keyword.' (?!([^<]+)?>)/i', $link, $text, $remaining, $count);
@@ -50,5 +49,34 @@ class Autolink extends Model
         });
 
         return $text;
+    }
+
+    protected static function shouldStopProcessing(int $counter, int $limit): bool
+    {
+        return $limit > -1 && $counter >= $limit;
+    }
+
+    protected static function shouldSkipDuplicateUrl(string $url, array $usedUrls): bool
+    {
+        return (bool) Rapidez::config(self::CONFIG_STOP_KEYWORD_PROCESSING, false) && in_array($url, $usedUrls);
+    }
+
+    /**
+     * Determine the maximum number of replacements allowed for this autolink.
+     * Respects both the global page limit and the keyword-specific limit by returning the lowest of the two.
+     * Returns -1 for unlimited replacements.
+     */
+    protected static function getRemainingReplacements(Autolink $autolink, int $globalLimit, int $counter): int
+    {
+        $keywordLimit = (int) ($autolink->max_replacements ?: -1);
+        $globalRemaining = $globalLimit > -1 ? max($globalLimit - $counter, 0) : -1;
+
+        return match (true) {
+            $globalRemaining === 0 => 0,
+            $globalRemaining > -1 && $keywordLimit > -1 => min($globalRemaining, $keywordLimit),
+            $globalRemaining > -1 => $globalRemaining,
+            $keywordLimit > -1 => $keywordLimit,
+            default => -1,
+        };
     }
 }

--- a/src/Models/Autolink.php
+++ b/src/Models/Autolink.php
@@ -72,11 +72,11 @@ class Autolink extends Model
         $globalRemaining = $globalLimit > -1 ? max($globalLimit - $counter, 0) : -1;
 
         return match (true) {
-            $globalRemaining === 0 => 0,
+            $globalRemaining === 0                      => 0,
             $globalRemaining > -1 && $keywordLimit > -1 => min($globalRemaining, $keywordLimit),
-            $globalRemaining > -1 => $globalRemaining,
-            $keywordLimit > -1 => $keywordLimit,
-            default => -1,
+            $globalRemaining > -1                       => $globalRemaining,
+            $keywordLimit > -1                          => $keywordLimit,
+            default                                     => -1,
         };
     }
 }


### PR DESCRIPTION
### Fix autolink per-page limit enforcement
Previously, the `links_limit_per_page` setting could be exceeded because `preg_replace` replaced all matches per keyword before checking the global counter. This fix calculates the remaining allowed replacements before each keyword iteration and passes that limit directly to `preg_replace`, ensuring the total number of autolinks never exceeds the configured limit.

### Implement avoid duplicate URLs in cross-links option
Added support for the `stop_keyword_processing` configuration option. When enabled, only the first keyword pointing to a specific URL will be converted to a link. Subsequent keywords targeting the same URL are skipped, preventing duplicate links and improving page performance.

### Add autolink number of substitutions support
Implemented support for the `max_replacements` field on individual autolink keywords. Each keyword can now have its own replacement limit that works alongside the global page limit. When both limits are set, the most restrictive one applies, ensuring neither limit is exceeded.

